### PR TITLE
Prepare to publish prototype extension

### DIFF
--- a/settings/chrome-atlassian-beta.json
+++ b/settings/chrome-atlassian-beta.json
@@ -1,14 +1,13 @@
 {
   "buildType": "production",
   "manifestV3": true,
-  "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCq7XsXE/uakq4aKMG5Smz2nc8VSaandriziGorxX08py3mTkab79GpWYu7j/hA3Yf7fkCLQnX8QoZGj7WdaMX6+b+eHxF7vYpOhEW/Bam7TOlb+5AVmL1KReG9PPTLz4dp+xA4WfK2dqFM+XN40FTbm2G/SNk3GRP3gQOxgy3ZKwIDAQAB",
 
   "apiUrl": "https://hypothesis-confluence-beta.herokuapp.com/api/",
   "authDomain": "hypothes.is",
   "bouncerUrl": "https://hyp.is/",
   "serviceUrl": "https://hypothes.is/",
 
-  "oauthClientId": "fd23fe2e-7792-11e7-8e16-23e47a1799d4",
+  "oauthClientId": "dummy-value",
 
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
 

--- a/settings/chrome-atlassian-dev.json
+++ b/settings/chrome-atlassian-dev.json
@@ -1,14 +1,13 @@
 {
   "buildType": "production",
   "manifestV3": true,
-  "key": "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCq7XsXE/uakq4aKMG5Smz2nc8VSaandriziGorxX08py3mTkab79GpWYu7j/hA3Yf7fkCLQnX8QoZGj7WdaMX6+b+eHxF7vYpOhEW/Bam7TOlb+5AVmL1KReG9PPTLz4dp+xA4WfK2dqFM+XN40FTbm2G/SNk3GRP3gQOxgy3ZKwIDAQAB",
 
   "apiUrl": "https://hypothesis-confluence-dev.ngrok.io/api/",
   "authDomain": "hypothes.is",
   "bouncerUrl": "https://hyp.is/",
   "serviceUrl": "https://hypothes.is/",
 
-  "oauthClientId": "fd23fe2e-7792-11e7-8e16-23e47a1799d4",
+  "oauthClientId": "dummy-value",
 
   "sentryPublicDSN": "https://934d4f62912b47d8bb03c28ae6670cf8@app.getsentry.com/69811",
 

--- a/src/background/browser-action.js
+++ b/src/background/browser-action.js
@@ -33,6 +33,12 @@ const badgeThemes = {
     defaultText: 'QA',
     color: '#EDA061', // Porche orange-pink
   },
+  production: {
+    defaultText: 'ATL',
+
+    // "Pacific bridge" color from https://atlassian.design/foundations/color
+    color: '#0052CC',
+  },
 };
 
 /**

--- a/src/manifest.json.mustache
+++ b/src/manifest.json.mustache
@@ -1,5 +1,5 @@
 {
-  "name": "Hypothesis - Web & PDF Annotation",
+  "name": "Hypothesis app for Confluence",
   "short_name": "Hypothesis",
   "version": "{{ version }}",
   {{#browserIsChrome}}


### PR DESCRIPTION
This PR tracks the changes required to publish a prototype version of the Hypothesis extension for Confluence.

Summary of changes:

- Incorporate the migration from Manifest V2 to Manifest V3 from https://github.com/hypothesis/browser-extension/pull/1031
- Replace the use of localStorage for remembering whether the extension is active in a tab with an alternative approach. This is based on a branch from Dec 2021 that I dug up
- Change the badge style and package metadata to distinguish this extension from the standard Hypothesis extension
  - Set the default badge text to "ATL"
  - Change the badge color to [Pacific Bridge](https://atlassian.design/foundations/color) (aka. the "Atlassian blue")
  - Change the extension name to "Hypothesis for Confluence"

To build the extension locally:

```
make build SETTINGS_FILE=settings/chrome-atlassian-beta.json
make SETTINGS_FILE=settings/chrome-atlassian-beta.json dist/chrome-extension.zip
```